### PR TITLE
Add AMI account IDs for sharing AMI with other AWS accounts

### DIFF
--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -1,5 +1,6 @@
 source "amazon-ebs" "builder" {
   ami_name              = "${var.ami_name_prefix}-${var.version}"
+  ami_users             = var.ami_account_ids
   communicator          = "ssh"
   instance_type         = var.aws_instance_type
   force_delete_snapshot = var.force_delete_snapshot

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -1,3 +1,8 @@
+variable "ami_account_ids" {
+  type        = list(string)
+  description = "A list of account IDs that have access to launch the resulting AMI(s)"
+}
+
 variable "ami_name_prefix" {
   type        = string
   default     = "grafana-ami"


### PR DESCRIPTION
Add AMI account IDs for sharing AMI with other AWS accounts.